### PR TITLE
Convert $config to an empty hash

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -166,6 +166,7 @@
 #
 # === Authors
 #
+# * Andrew Langhorn <mailto:andrew@ajlanghorn.com>
 # * Richard Pijnenburg <mailto:richard.pijnenburg@elasticsearch.com>
 #
 class elasticsearch(
@@ -188,7 +189,7 @@ class elasticsearch(
   $init_defaults         = undef,
   $init_defaults_file    = undef,
   $init_template         = undef,
-  $config                = undef,
+  $config                = {},
   $datadir               = $elasticsearch::params::datadir,
   $plugindir             = $elasticsearch::params::plugindir,
   $plugintool            = $elasticsearch::params::plugintool,


### PR DESCRIPTION
When using this, the 'undef' value of the $config parameter posed an issue
because Puppet interprets values as strings unless otherwise specified, yet
the Puppet merge function in instance.pp was expecting a hash.

To get around this, committing an empty hash as the default value.