### PR TITLE
Fix conflicting data.path in config and datadir option

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -168,7 +168,15 @@ define elasticsearch::instance(
       $main_config = { }
     }
 
-    $instance_datadir_config = { 'path.data' => $instance_datadir }
+    if(has_key($instance_config, 'path.data')) {
+      $instance_datadir_config = { 'path.data' => $instance_datadir }
+    } elsif(has_key($instance_config, 'path')) {
+      if(has_key($instance_config['path'], 'data')) {
+        $instance_datadir_config = { 'path' => { 'data' => $instance_datadir } }
+      }
+    } else {
+      $instance_datadir_config = { 'path.data' => $instance_datadir }
+    }
 
     if(is_array($instance_datadir)) {
       $dirs = join($instance_datadir, ' ')

--- a/spec/defines/005_elasticsearch_instance_spec.rb
+++ b/spec/defines/005_elasticsearch_instance_spec.rb
@@ -257,6 +257,32 @@ describe 'elasticsearch::instance', :type => 'define' do
       it { should contain_file('/var/lib/elasticsearch-data/02').with( :ensure => 'directory') }
     end
 
+   context "Conflicting setting path.data" do
+     let(:pre_condition) { 'class {"elasticsearch": }'  }
+     let :params do {
+       :datadir => '/var/lib/elasticsearch/data',
+       :config  => { 'path.data' => '/var/lib/elasticsearch/otherdata' }
+     } end
+
+      it { should contain_exec('mkdir_datadir_elasticsearch_es-01') }
+      it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml').with(:content => "### MANAGED BY PUPPET ###\n---\nnode: \n  name: elasticsearch001-es-01\npath: \n  data: /var/lib/elasticsearch/data\n" ) }
+      it { should contain_file('/var/lib/elasticsearch/data').with( :ensure => 'directory') }
+      it { should_not contain_file('/var/lib/elasticsearch/otherdata').with( :ensure => 'directory') }
+   end
+
+   context "Conflicting setting path => data" do
+     let(:pre_condition) { 'class {"elasticsearch": }'  }
+     let :params do {
+       :datadir => '/var/lib/elasticsearch/data',
+       :config  => { 'path' => { 'data' => '/var/lib/elasticsearch/otherdata' } }
+     } end
+
+      it { should contain_exec('mkdir_datadir_elasticsearch_es-01') }
+      it { should contain_file('/etc/elasticsearch/es-01/elasticsearch.yml').with(:content => "### MANAGED BY PUPPET ###\n---\nnode: \n  name: elasticsearch001-es-01\npath: \n  data: /var/lib/elasticsearch/data\n" ) }
+      it { should contain_file('/var/lib/elasticsearch/data').with( :ensure => 'directory') }
+      it { should_not contain_file('/var/lib/elasticsearch/otherdata').with( :ensure => 'directory') }
+   end
+
   end
 
   context "Logging" do


### PR DESCRIPTION
In some cases people would define a data.path setting in the config and use the datadir option.
We should detect this and force the datadir option to be leading.

Fixes #186