### PR TITLE
Fix possible service resource name conflict

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -141,7 +141,6 @@ class elasticsearch::params {
       $defaults_location  = '/etc/sysconfig'
       $init_template      = 'elasticsearch.RedHat.erb'
       $pid_dir            = '/var/run/elasticsearch'
-      $logdir_group       = $elasticsearch::elasticsearch_group
     }
     'Debian', 'Ubuntu': {
       $service_name       = 'elasticsearch'
@@ -152,7 +151,6 @@ class elasticsearch::params {
       $defaults_location  = '/etc/default'
       $init_template      = 'elasticsearch.Debian.erb'
       $pid_dir            = false
-      $logdir_group       = $elasticsearch::elasticsearch_user
     }
     'Darwin': {
       $service_name       = 'FIXME/TODO'
@@ -162,7 +160,6 @@ class elasticsearch::params {
       $service_providers  = [ 'launchd' ]
       $defaults_location  = false
       $pid_dir            = false
-      $logdir_group       = $elasticsearch::elasticsearch_group
     }
     'OpenSuSE': {
       $service_name       = 'elasticsearch'
@@ -173,7 +170,6 @@ class elasticsearch::params {
       $defaults_location  = '/etc/sysconfig'
       $init_template      = 'elasticsearch.OpenSuSE.erb'
       $pid_dir            = false
-      $logdir_group       = $elasticsearch::elasticsearch_group
     }
     default: {
       fail("\"${module_name}\" provides no service parameters

--- a/manifests/service/init.pp
+++ b/manifests/service/init.pp
@@ -108,7 +108,7 @@ define elasticsearch::service::init(
   }
 
   $notify_service = $elasticsearch::restart_on_change ? {
-    true  => Service[$name],
+    true  => Service["elasticsearch-instance-${name}"],
     false => undef,
   }
 
@@ -123,7 +123,7 @@ define elasticsearch::service::init(
         owner  => 'root',
         group  => 'root',
         mode   => '0644',
-        before => Service[$name],
+        before => Service["elasticsearch-instance-${name}"],
         notify => $notify_service
       }
 
@@ -142,7 +142,7 @@ define elasticsearch::service::init(
         incl    => "${elasticsearch::params::defaults_location}/elasticsearch-${name}",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
-        before  => Service[$name],
+        before  => Service["elasticsearch-instance-${name}"],
         notify  => $notify_service
       }
 
@@ -157,7 +157,7 @@ define elasticsearch::service::init(
         owner   => 'root',
         group   => 'root',
         mode    => '0755',
-        before  => Service[$name],
+        before  => Service["elasticsearch-instance-${name}"],
         notify  => $notify_service
       }
 
@@ -167,12 +167,12 @@ define elasticsearch::service::init(
 
     file { "/etc/init.d/elasticsearch-${name}":
       ensure    => 'absent',
-      subscribe => Service[$name]
+      subscribe => Service["elasticsearch-instance-${name}"]
     }
 
     file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
       ensure    => 'absent',
-      subscribe => Service[$name]
+      subscribe => Service["elasticsearch-${$name}"]
     }
 
   }
@@ -181,7 +181,7 @@ define elasticsearch::service::init(
   if ( $status != 'unmanaged') {
 
     # action
-    service { $name:
+    service { "elasticsearch-instance-${name}":
       ensure     => $service_ensure,
       enable     => $service_enable,
       name       => "elasticsearch-${name}",

--- a/manifests/service/systemd.pp
+++ b/manifests/service/systemd.pp
@@ -104,7 +104,7 @@ define elasticsearch::service::systemd(
   }
 
   $notify_service = $elasticsearch::restart_on_change ? {
-    true  => [ Exec["systemd_reload_${name}"], Service[$name] ],
+    true  => [ Exec["systemd_reload_${name}"], Service["elasticsearch-instance-${name}"] ],
     false => Exec["systemd_reload_${name}"]
   }
 
@@ -118,7 +118,7 @@ define elasticsearch::service::systemd(
         owner  => 'root',
         group  => 'root',
         mode   => '0644',
-        before => Service[$name],
+        before => Service["elasticsearch-instance-${name}"],
         notify => $notify_service
       }
 
@@ -137,7 +137,7 @@ define elasticsearch::service::systemd(
         incl    => "${elasticsearch::params::defaults_location}/elasticsearch-${name}",
         lens    => 'Shellvars.lns',
         changes => template("${module_name}/etc/sysconfig/defaults.erb"),
-        before  => Service[$name],
+        before  => Service["elasticsearch-instance-${name}"],
         notify  => $notify_service
       }
 
@@ -149,7 +149,7 @@ define elasticsearch::service::systemd(
       file { "/usr/lib/systemd/system/elasticsearch-${name}.service":
         ensure  => $ensure,
         content => template($init_template),
-        before  => Service[$name],
+        before  => Service["elasticsearch-instance-${name}"],
         notify  => $notify_service
       }
 
@@ -161,13 +161,13 @@ define elasticsearch::service::systemd(
 
     file { "/usr/lib/systemd/system/elasticsearch-${name}.service":
       ensure    => 'absent',
-      subscribe => Service[$name],
+      subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"]
     }
 
     file { "${elasticsearch::params::defaults_location}/elasticsearch-${name}":
       ensure    => 'absent',
-      subscribe => Service[$name],
+      subscribe => Service["elasticsearch-instance-${name}"],
       notify    => Exec["systemd_reload_${name}"]
     }
 
@@ -183,7 +183,7 @@ define elasticsearch::service::systemd(
   if ($status != 'unmanaged') {
 
     # action
-    service { $name:
+    service { "elasticsearch-instance-${name}":
       ensure     => $service_ensure,
       enable     => $service_enable,
       name       => "elasticsearch-${name}.service",

--- a/spec/defines/004_elasticsearch_plugin_spec.rb
+++ b/spec/defines/004_elasticsearch_plugin_spec.rb
@@ -19,7 +19,7 @@ describe 'elasticsearch::plugin', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__plugin('mobz/elasticsearch-head') }
-    it { should contain_exec('install_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head', :creates => '/usr/share/elasticsearch/plugins/head') }
+    it { should contain_exec('install_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin -install mobz/elasticsearch-head', :creates => '/usr/share/elasticsearch/plugins/head', :notify => 'Elasticsearch::Service[es-01]') }
   end
 
   context "Remove a plugin" do
@@ -31,7 +31,7 @@ describe 'elasticsearch::plugin', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__plugin('mobz/elasticsearch-head') }
-    it { should contain_exec('remove_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin --remove head', :onlyif => 'test -d /usr/share/elasticsearch/plugins/head') }
+    it { should contain_exec('remove_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin --remove head', :onlyif => 'test -d /usr/share/elasticsearch/plugins/head', :notify => 'Elasticsearch::Service[es-01]') }
   end
 
   context "Use a proxy" do
@@ -45,7 +45,7 @@ describe 'elasticsearch::plugin', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__plugin('mobz/elasticsearch-head') }
-    it { should contain_exec('install_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin -DproxyPort=3128 -DproxyHost=my.proxy.com -install mobz/elasticsearch-head', :creates => '/usr/share/elasticsearch/plugins/head') }
+    it { should contain_exec('install_plugin_mobz/elasticsearch-head').with(:command => '/usr/share/elasticsearch/bin/plugin -DproxyPort=3128 -DproxyHost=my.proxy.com -install mobz/elasticsearch-head', :creates => '/usr/share/elasticsearch/plugins/head', :notify => 'Elasticsearch::Service[es-01]') }
   end
 
 end

--- a/spec/defines/010_elasticsearch_service_init_spec.rb
+++ b/spec/defines/010_elasticsearch_service_init_spec.rb
@@ -19,7 +19,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__service__init('es-01') }
-    it { should contain_service('es-01').with(:ensure => 'running', :enable => true) }
+    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'running', :enable => true) }
   end
 
   context "Remove service" do
@@ -29,7 +29,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__service__init('es-01') }
-    it { should contain_service('es-01').with(:ensure => 'stopped', :enable => false) }
+    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'stopped', :enable => false) }
   end
 
   context "unmanaged" do
@@ -39,7 +39,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
       } end
 
     it { should contain_elasticsearch__service__init('es-01') }
-      it { should_not contain_service('es-01') }
+      it { should_not contain_service('elasticsearch-instance-es-01') }
       it { should_not contain_file('/etc/init.d/elasticsearch-es-01') }
       it { should_not contain_file('/etc/sysconfig/elasticsearch-es-01') }
 
@@ -54,7 +54,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
 	:init_defaults_file => 'puppet:///path/to/initdefaultsfile'
       } end
 
-      it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Service[es-01]', :before => 'Service[es-01]') }
+      it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "Set via hash" do
@@ -64,7 +64,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
 	:init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
       } end
 
-      it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => 'Service[es-01]', :before => 'Service[es-01]') }
+      it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "No restart when 'restart_on_change' is false" do
@@ -77,7 +77,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
 	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
         } end
 
-        it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => nil, :before => 'Service[es-01]') }
+        it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }
       end
 
       context "Set via hash" do
@@ -87,7 +87,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
   	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
         } end
 
-        it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => nil, :before => 'Service[es-01]') }
+        it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }
       end
 
     end
@@ -104,7 +104,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
       } end
 
-      it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => 'Service[es-01]', :before => 'Service[es-01]') }
+      it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => 'Service[elasticsearch-instance-es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "No restart when 'restart_on_change' is false" do
@@ -116,7 +116,7 @@ describe 'elasticsearch::service::init', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.RedHat.erb'
       } end
 
-      it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => nil, :before => 'Service[es-01]') }
+      it { should contain_file('/etc/init.d/elasticsearch-es-01').with(:notify => nil, :before => 'Service[elasticsearch-instance-es-01]') }
 
     end
 

--- a/spec/defines/011_elasticsearch_service_system_spec.rb
+++ b/spec/defines/011_elasticsearch_service_system_spec.rb
@@ -20,7 +20,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
     it { should contain_elasticsearch__service__systemd('es-01') }
     it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
-    it { should contain_service('es-01').with(:ensure => 'running', :enable => true, :provider => 'systemd') }
+    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'running', :enable => true, :provider => 'systemd') }
   end
 
   context "Remove service" do
@@ -31,7 +31,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 
     it { should contain_elasticsearch__service__systemd('es-01') }
     it { should contain_exec('systemd_reload_es-01').with(:command => '/bin/systemctl daemon-reload') }
-    it { should contain_service('es-01').with(:ensure => 'stopped', :enable => false, :provider => 'systemd') }
+    it { should contain_service('elasticsearch-instance-es-01').with(:ensure => 'stopped', :enable => false, :provider => 'systemd') }
   end
 
   context "unmanaged" do
@@ -41,7 +41,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
     } end
 
     it { should contain_elasticsearch__service__systemd('es-01') }
-    it { should_not contain_service('es-01') }
+    it { should_not contain_service('elasticsearch-instance-es-01') }
     it { should_not contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service') }
     it { should_not contain_file('/etc/sysconfig/elasticsearch-es-01') }
 
@@ -56,7 +56,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_defaults_file => 'puppet:///path/to/initdefaultsfile'
       } end
 
-      it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :before => 'Service[es-01]') }
+      it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "Set via hash" do
@@ -66,7 +66,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
       } end
 
-      it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :before => 'Service[es-01]') }
+      it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "No restart when 'restart_on_change' is false" do
@@ -79,7 +79,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	  :init_defaults_file => 'puppet:///path/to/initdefaultsfile'
         } end
 
-        it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[es-01]') }
+        it { should contain_file('/etc/sysconfig/elasticsearch-es-01').with(:source => 'puppet:///path/to/initdefaultsfile', :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
       end
 
       context "Set via hash" do
@@ -89,7 +89,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
   	  :init_defaults => {'ES_HOME' => '/usr/share/elasticsearch' }
         } end
 
-        it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[es-01]') }
+        it { should contain_augeas('defaults_es-01').with(:incl => '/etc/sysconfig/elasticsearch-es-01', :changes => "set ES_GROUP 'elasticsearch'\nset ES_HOME '/usr/share/elasticsearch'\nset ES_USER 'elasticsearch'\n", :notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
       end
 
     end
@@ -106,7 +106,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.OpenSuSE.erb'
       } end
 
-      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[es-01]') }
+      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:before => 'Service[elasticsearch-instance-es-01]') }
     end
 
     context "No restart when 'restart_on_change' is false" do
@@ -118,7 +118,7 @@ describe 'elasticsearch::service::systemd', :type => 'define' do
 	:init_template => 'elasticsearch/etc/init.d/elasticsearch.OpenSuSE.erb'
       } end
 
-      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[es-01]') }
+      it { should contain_file('/usr/lib/systemd/system/elasticsearch-es-01.service').with(:notify => 'Exec[systemd_reload_es-01]', :before => 'Service[elasticsearch-instance-es-01]') }
 
     end
 


### PR DESCRIPTION
When defining an instance the service resource gets the instance name.
While the resulting service is `elasticsearch-$name` it could happen that the service resource name can conflict with other modules.