### PR TITLE
Export ES_CLASSPATH in init scripts, resolves #232

### DIFF
--- a/templates/etc/init.d/elasticsearch.Debian.erb
+++ b/templates/etc/init.d/elasticsearch.Debian.erb
@@ -109,6 +109,7 @@ export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
+export ES_CLASSPATH
 
 # Check DAEMON exists
 test -x $DAEMON || exit 0

--- a/templates/etc/init.d/elasticsearch.RedHat.erb
+++ b/templates/etc/init.d/elasticsearch.RedHat.erb
@@ -41,6 +41,7 @@ export ES_HEAP_SIZE
 export ES_HEAP_NEWSIZE
 export ES_DIRECT_SIZE
 export ES_JAVA_OPTS
+export ES_CLASSPATH
 
 lockfile=/var/lock/subsys/$prog
 


### PR DESCRIPTION
Allows ES_CLASSPATH to be specified in init_defaults Hash like other ES_* variables. Useful for using at least elasticsearch-hadoop's hdfs repository plugin that allows you to import your own Hadoop jars. More details:
https://github.com/elasticsearch/puppet-elasticsearch/issues/232