### PR TITLE
fix bin permissons issue

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -55,6 +55,12 @@ class elasticsearch::config {
       recurse => true
     }
 
+    file { "${elasticsearch::params::homedir}/bin":
+      ensure  => 'directory',
+      recurse => true,
+      mode    => '0744'
+    }
+
     file { $elasticsearch::params::homedir:
       ensure  => 'directory',
       recurse => true


### PR DESCRIPTION
Fix binary path permissions issue. 

In some cases wrong permissions sets to binary scripts because of recursive puppet attribute in use at homedir path. 

example of wrong behavior 
Notice: /Stage[main]/Elasticsearch::Config/File[/usr/share/elasticsearch/bin/elasticsearch]/mode: mode changed '0644' to '0744'
Notice: /Stage[main]/Elasticsearch::Config/File[/usr/share/elasticsearch/bin/plugin]/mode: mode changed '0644' to '0744'
Notice: /Stage[main]/Elasticsearch::Config/File[/usr/share/elasticsearch/bin/elasticsearch.in.sh]/mode: mode changed '0644' to '0744'