### PR TITLE
Added missing puppetlab-java dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,6 +12,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 3.2.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/java",
+      "version_requirement": ">= 1.3.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
It turns out that the latest version of this module (0.9.0) requires **java** module to be installed or else puppet will fail if **java_install** variable is **true**

```
Error: Puppet::Parser::AST::Resource failed with error ArgumentError: Could not find declared class ::java at /home/ubuntu/all-125/modules/elasticsearch/manifests/init.pp:331 on node elasticsearch01.localdomain
```

Unfortunately, **puppetlabs/java** module has yet to be added as one of the dependencies. 

This pull request is a simple fix for that.