### PR TITLE
Set undefined variables to work with strict_variables

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -278,6 +278,8 @@ define elasticsearch::instance(
 
     $require_service = undef
     $before_service  = File[$instance_configdir]
+
+    $init_defaults_new = {}
   }
 
   elasticsearch::service { $name:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,6 +147,7 @@ class elasticsearch::params {
 
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
+      $service_hasstatus  = false
       $service_pattern    = $service_name
       $defaults_location  = '/etc/sysconfig'
       $pid_dir            = '/var/run/elasticsearch'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -147,7 +147,7 @@ class elasticsearch::params {
 
       $service_name       = 'elasticsearch'
       $service_hasrestart = true
-      $service_hasstatus  = false
+      $service_hasstatus  = true
       $service_pattern    = $service_name
       $defaults_location  = '/etc/sysconfig'
       $pid_dir            = '/var/run/elasticsearch'


### PR DESCRIPTION
Some changes to avoid errors when strict variables are enabled.

Would previously fail when removing any instance, and when creating an instance on CentOS.

Assuming `service_hasstatus` should be false as it would have interpreted `undef` as such, but if the RedHat/CentOS service does support status then that should be true.