### PR TITLE
es_instance_conn_validator: Resource to verify instance availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,25 @@ elasticsearch::python { 'rawes': }
 elasticsearch::ruby { 'elasticsearch': }
 ```
 
+###Connection Validator
+
+This module offers a way to make sure an instance has been started and is up and running before
+doing a next action. This is done via the use of the `es_instance_conn_validator` resource.
+```puppet
+es_instance_conn_validator { 'myinstance' :
+  server => 'es.example.com',
+  port   => '9200',
+}
+```
+
+A common use would be for example :
+
+```puppet
+class { 'kibana4' :
+  require => Es_Instance_Conn_Validator['myinstance'],
+}
+```
+
 ###Package installation
 
 There are 2 different ways of installing the software

--- a/lib/puppet/provider/es_instance_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/es_instance_conn_validator/tcp_port.rb
@@ -1,0 +1,51 @@
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__),"..","..",".."))
+require 'puppet/util/es_instance_validator'
+
+# This file contains a provider for the resource type `es_instance_conn_validator`,
+# which validates the Elasticsearch instance connection by attempting an https connection.
+
+Puppet::Type.type(:es_instance_conn_validator).provide(:tcp_port) do
+  desc "A provider for the resource type `es_instance_conn_validator`,
+        which validates the  connection by attempting an https
+        connection to the Elasticsearch instance." 
+
+  def exists?
+    start_time = Time.now
+    timeout = resource[:timeout]
+
+    success = validator.attempt_connection
+
+    while success == false && ((Time.now - start_time) < timeout)
+      # It can take several seconds for the Elasticsearch instance to start up;
+      # especially on the first install.  Therefore, our first connection attempt
+      # may fail.  Here we have somewhat arbitrarily chosen to retry every 2
+      # seconds until the configurable timeout has expired.
+      Puppet.debug("Failed to connect to the Elasticsearch instance; sleeping 2 seconds before retry")
+      sleep 2
+      success = validator.attempt_connection
+    end
+
+    if success
+      Puppet.debug("Connected to the ES instance in #{Time.now - start_time} seconds.")
+    else
+      Puppet.notice("Failed to connect to the ES instance within timeout window of #{timeout} seconds; giving up.")
+    end
+
+    success
+  end
+
+  def create
+    # If `#create` is called, that means that `#exists?` returned false, which
+    # means that the connection could not be established... so we need to
+    # cause a failure here.
+    raise Puppet::Error, "Unable to connect to ES instance ! (#{@validator.instance_server}:#{@validator.instance_port})"
+  end
+
+  private
+
+  # @api private
+  def validator
+    @validator ||= Puppet::Util::EsInstanceValidator.new(resource[:server], resource[:port])
+  end
+
+end

--- a/lib/puppet/type/es_instance_conn_validator.rb
+++ b/lib/puppet/type/es_instance_conn_validator.rb
@@ -1,0 +1,38 @@
+Puppet::Type.newtype(:es_instance_conn_validator) do
+
+  @doc = "Verify that a connection can be successfully established between a node
+  and the Elasticsearch instance. It could potentially be used for other
+  purposes such as monitoring."
+  
+  ensurable do
+    defaultvalues
+    defaultto :present
+  end
+
+  newparam(:name, :namevar => true) do
+    desc 'An arbitrary name used as the identity of the resource.'
+  end
+
+  newparam(:server) do
+    desc 'DNS name or IP address of the server where Elasticsearch instance should be running.'
+    defaultto 'localhost'
+  end
+
+  newparam(:port) do
+    desc 'The port that the Elasticsearch instance should be listening on.'
+    defaultto 9200
+  end
+
+  newparam(:timeout) do
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that the Elasticsearch instance is not running; defaults to 60 seconds.'
+    defaultto 60
+    validate do |value|
+      # This will raise an error if the string is not convertible to an integer
+      Integer(value)
+    end
+    munge do |value|
+      Integer(value)
+    end
+  end
+
+end

--- a/lib/puppet/util/es_instance_validator.rb
+++ b/lib/puppet/util/es_instance_validator.rb
@@ -1,0 +1,36 @@
+require 'socket'
+require 'timeout'
+
+module Puppet
+  module Util
+    class EsInstanceValidator
+      attr_reader :instance_server
+      attr_reader :instance_port
+
+      def initialize(instance_server, instance_port)
+        @instance_server = instance_server
+        @instance_port   = instance_port
+      end
+
+      # Utility method; attempts to make an https connection to the Elasticsearch instance.
+      # This is abstracted out into a method so that it can be called multiple times
+      # for retry attempts.
+      #
+      # @return true if the connection is successful, false otherwise.
+      def attempt_connection
+        Timeout::timeout(Puppet[:configtimeout]) do
+          begin
+            TCPSocket.new(@instance_server, @instance_port).close
+            true
+          rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH => e
+            Puppet.debug "Unable to connect to Elasticsearch instance (#{@instance_server}:#{@instance_port}): #{e.message}"
+            false
+          end
+        end
+      rescue Timeout::Error
+        false
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
This commit brings a new resource `es_instance_conn_validator` that
aims to validate that an instance is up & running.

Fix: #275 